### PR TITLE
docs: document macOS/Xcode requirement for Cursor Cloud agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Platform requirement (important)
+
+`SiteSinc` is a **native iOS/iPadOS app** built with **Xcode** (`SiteSinc.xcodeproj`). It
+requires **macOS + Xcode 16 + the iOS 18 SDK/Simulator** to build, test, lint, or run.
+
+- Target: `IPHONEOS_DEPLOYMENT_TARGET = 18.0`, `SUPPORTED_PLATFORMS = iphonesimulator iphoneos`.
+- Uses Apple-only frameworks throughout: `SwiftUI`, `UIKit`, `CoreData`, `SwiftData`,
+  `PhotosUI`, `PDFKit`, `WebKit`, `UserNotifications`, `CoreLocation`, `AVFoundation`,
+  `LocalAuthentication`.
+- Code signing is automatic (`Apple Development`, `DEVELOPMENT_TEAM = SX6FRQ2PP9`).
+
+**Cursor Cloud Agent VMs run Linux (Ubuntu x86_64), so this project cannot be built,
+tested, or run in the cloud environment.** `xcodebuild`/`xcrun`/`swift` are not available,
+and the open-source Swift Linux toolchain does not ship the Apple UI/data frameworks this
+app depends on. Do not attempt to create a Linux build/run setup for this repo — it is a
+fundamental OS incompatibility, not a missing dependency.
+
+### How to build / test / run (on macOS only)
+
+Use the shared scheme `SiteSinc` (`SiteSinc.xcodeproj/xcshareddata/xcschemes/SiteSinc.xcscheme`):
+
+- Build: `xcodebuild -project SiteSinc.xcodeproj -scheme SiteSinc -sdk iphonesimulator build`
+- Test: `xcodebuild -project SiteSinc.xcodeproj -scheme SiteSinc -destination 'platform=iOS Simulator,name=iPhone 16' test`
+  (test targets: `SiteSincTests`, `SiteSincUITests`).
+- Run: open `SiteSinc.xcodeproj` in Xcode and run on an iOS Simulator or device.
+
+### Notes
+
+- There is no dependency manager (no Swift Package Manager `Package.swift`, no CocoaPods,
+  no Carthage), so there is nothing to install before building in Xcode.
+- The app talks to a remote backend over HTTPS (see `SiteSinc/APIClient.swift` and
+  `NOTIFICATION_SETUP.md`); the backend is not part of this repository.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`SiteSinc` is a native iOS/iPadOS SwiftUI app built with Xcode (`SiteSinc.xcodeproj`). It cannot be built, tested, linted, or run on Cursor Cloud Agent VMs, which are Linux (Ubuntu x86_64). Building requires macOS + Xcode 16 + the iOS 18 SDK/Simulator, and every source file depends on Apple-only frameworks (`SwiftUI`, `UIKit`, `CoreData`, `SwiftData`, `PhotosUI`, `PDFKit`, `WebKit`, `UserNotifications`, `CoreLocation`, `AVFoundation`, `LocalAuthentication`).

This PR adds an `AGENTS.md` with a `## Cursor Cloud specific instructions` section so future cloud agents know:
- This is a fundamental OS incompatibility (not a missing Linux dependency), so they should not attempt a Linux build/run setup.
- The correct macOS-only build/test/run commands (using the shared `SiteSinc` scheme).
- There is no dependency manager (no SPM/CocoaPods/Carthage), so nothing to install before building in Xcode.

## Environment setup outcome

No update script was configured because there are no Linux-installable dependencies for this Xcode project, and no services in this repo can run on Linux. The repo contains only the iOS client; the backend referenced in `NOTIFICATION_SETUP.md` is not part of this repository.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b18fedd-dbc3-4c31-8eec-92968960dcc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b18fedd-dbc3-4c31-8eec-92968960dcc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

