### PR TITLE
Fix Face ID toggle persistence and keyboard submit behavior

### DIFF
--- a/SiteSinc/LoginView.swift
+++ b/SiteSinc/LoginView.swift
@@ -13,6 +13,12 @@ struct LoginView: View {
     @State private var resetError = ""
     @State private var resetSuccess = false
     @State private var resetLoading = false
+    @FocusState private var focusedField: Field?
+
+    private enum Field {
+        case email
+        case password
+    }
 
     private func handleLogin() {
         guard !email.isEmpty, !password.isEmpty else {
@@ -105,6 +111,11 @@ struct LoginView: View {
             }
         }
         return "Login failed: \(error.localizedDescription)"
+    }
+
+    private func submitLoginFromKeyboard() {
+        focusedField = nil
+        handleLogin()
     }
 
     private func attemptFaceIDLogin() {
@@ -272,16 +283,22 @@ struct LoginView: View {
                         .foregroundColor(.black)
                         .autocapitalization(.none)
                         .keyboardType(.emailAddress)
+                        .submitLabel(.next)
+                        .focused($focusedField, equals: .email)
                         .disabled(isLoading)
-                        .onSubmit { handleLogin() }
+                        .onSubmit {
+                            focusedField = .password
+                        }
 
                     SecureField("Password", text: $password)
                         .padding()
                         .background(Color.gray.opacity(0.1))
                         .cornerRadius(8)
                         .foregroundColor(.black)
+                        .submitLabel(.go)
+                        .focused($focusedField, equals: .password)
                         .disabled(isLoading)
-                        .onSubmit { handleLogin() }
+                        .onSubmit { submitLoginFromKeyboard() }
 
                     HStack {
                         Spacer()
@@ -295,9 +312,7 @@ struct LoginView: View {
 
                     Button(action: {
                         withAnimation(.spring()) {
-                            // Explicitly set isLoading for button press,
-                            // as Face ID might not have run or might have set it to false.
-                            if !isLoading { isLoading = true }
+                            focusedField = nil
                             handleLogin()
                         }
                     }) {
@@ -327,6 +342,14 @@ struct LoginView: View {
                 .frame(maxWidth: 400)
             }
             .ignoresSafeArea(.keyboard)
+            .toolbar {
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("Done") {
+                        focusedField = nil
+                    }
+                }
+            }
             .sheet(isPresented: $showResetDialog) {
                 // ... (your existing password reset sheet remains the same) ...
                 VStack(spacing: 16) {

--- a/SiteSinc/ProjectListView.swift
+++ b/SiteSinc/ProjectListView.swift
@@ -1103,7 +1103,7 @@ struct ProfileView: View {
     @State private var showPendingSyncs = false
     @State private var activityMonitoringEnabled: Bool = true
     @State private var showSignOutConfirmation = false
-    @State private var faceIDEnabled: Bool = KeychainHelper.hasStoredPassword()
+    @State private var faceIDEnabled: Bool = KeychainHelper.hasStoredPassword() && KeychainHelper.getEmail() != nil
     @State private var biometricsAvailable: Bool = false
     @State private var showEnableFaceIDSheet = false
 
@@ -1503,11 +1503,16 @@ struct ProfileView: View {
         .sheet(isPresented: $showPendingSyncs) {
             PendingSubmissionsView()
         }
-        .sheet(isPresented: $showEnableFaceIDSheet) {
+        .sheet(
+            isPresented: $showEnableFaceIDSheet,
+            onDismiss: {
+                faceIDEnabled = KeychainHelper.hasStoredPassword() && KeychainHelper.getEmail() != nil
+            }
+        ) {
             EnableFaceIDSheet(
                 email: sessionManager.user?.email ?? KeychainHelper.getEmail() ?? "",
                 onSuccess: {
-                    faceIDEnabled = true
+                    faceIDEnabled = KeychainHelper.hasStoredPassword() && KeychainHelper.getEmail() != nil
                     showEnableFaceIDSheet = false
                 },
                 onCancel: {
@@ -1518,7 +1523,7 @@ struct ProfileView: View {
         .onAppear {
             activityMonitoringEnabled = AnalyticsService.shared.isActivityMonitoringEnabled
             biometricsAvailable = LAContext().canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
-            faceIDEnabled = KeychainHelper.hasStoredPassword()
+            faceIDEnabled = KeychainHelper.hasStoredPassword() && KeychainHelper.getEmail() != nil
         }
     }
     
@@ -1627,6 +1632,7 @@ private struct EnableFaceIDSheet: View {
     @State private var password: String = ""
     @State private var error: String = ""
     @State private var isVerifying = false
+    @FocusState private var isPasswordFocused: Bool
 
     var body: some View {
         NavigationStack {
@@ -1661,6 +1667,8 @@ private struct EnableFaceIDSheet: View {
                     .padding()
                     .background(Color.gray.opacity(0.1))
                     .cornerRadius(8)
+                    .submitLabel(.go)
+                    .focused($isPasswordFocused)
                     .disabled(isVerifying)
                     .onSubmit { verify() }
 
@@ -1691,22 +1699,40 @@ private struct EnableFaceIDSheet: View {
                     Button("Cancel") { onCancel() }
                         .disabled(isVerifying)
                 }
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("Done") {
+                        isPasswordFocused = false
+                    }
+                }
             }
         }
     }
 
     private func verify() {
         guard !password.isEmpty else { return }
+        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalizedEmail.isEmpty else {
+            error = "Unable to enable Face ID because your email is unavailable."
+            return
+        }
         isVerifying = true
         error = ""
         Task {
             do {
-                _ = try await APIClient.login(email: email, password: password)
+                _ = try await APIClient.login(email: normalizedEmail, password: password)
                 await MainActor.run {
-                    _ = KeychainHelper.saveEmail(email)
-                    _ = KeychainHelper.savePassword(password)
-                    isVerifying = false
-                    onSuccess()
+                    let didSaveEmail = KeychainHelper.saveEmail(normalizedEmail)
+                    let didSavePassword = KeychainHelper.savePassword(password)
+                    if didSaveEmail && didSavePassword {
+                        isVerifying = false
+                        onSuccess()
+                    } else {
+                        // Keep keychain in a consistent state if one save succeeds and the other fails.
+                        _ = KeychainHelper.deleteCredentials()
+                        self.error = "Couldn't save Face ID credentials. Please try again."
+                        isVerifying = false
+                    }
                 }
             } catch {
                 await MainActor.run {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Make Face ID setup from the profile sidebar only succeed when credentials are actually saved to Keychain.
- Keep the sidebar toggle state in sync with persisted credentials on sheet dismiss and on appear.
- Improve login keyboard behavior: Enter on email moves to password, Enter on password submits login and dismisses keyboard, and add a keyboard Done button.
- Dismiss keyboard before manual sign-in tap without pre-setting loading state.

## Testing
- `command -v xcodebuild || echo xcodebuild_not_found` (shows iOS build tooling is unavailable in this Linux cloud environment)
- `which xcodebuild && xcodebuild -project SiteSinc.xcodeproj -scheme SiteSinc -destination 'generic/platform=iOS Simulator' build` (not runnable because `xcodebuild` is unavailable)

## Notes
- Branch is based on `aichat` as requested.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d97791db-e575-4df1-b529-1837cd3e214a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d97791db-e575-4df1-b529-1837cd3e214a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

