### PR TITLE
Fix camera and image fields inside form repeaters

### DIFF
--- a/SiteSinc/Forms/FormSubmissionCreateView.swift
+++ b/SiteSinc/Forms/FormSubmissionCreateView.swift
@@ -786,13 +786,22 @@ struct FormSubmissionCreateView: View {
                      // Find the field to check if it's a repeater or table
                      if let field = revision.fields.first(where: { $0.id == key }) {
                         if field.type == "repeater" {
-                            // Parse JSON string back to array for repeater fields
-                            if let data = value.data(using: .utf8),
-                               let jsonArray = try? JSONSerialization.jsonObject(with: data) {
-                                processedFormData[key] = jsonArray
-                            } else {
-                                processedFormData[key] = []
-                            }
+                            let rewritten = try await RepeaterMediaSupport.rewriteRowsForSubmission(
+                                RepeaterMediaSupport.parseRows(from: value),
+                                subFields: field.subFields ?? [],
+                                parentFieldId: field.id,
+                                uploadJPEG: { jpeg, fileName in
+                                    try await self.uploadFileDataAsync(
+                                        jpeg,
+                                        fileName: fileName,
+                                        fieldId: field.id,
+                                        projectId: self.projectId,
+                                        mimeType: "image/jpeg"
+                                    )
+                                },
+                                fileKeyFromRef: { self.extractFileKey(from: $0) ?? $0 }
+                            )
+                            processedFormData[key] = rewritten
                         } else if field.type == "table" {
                             // Parse JSON string back to array for table fields
                             if let data = value.data(using: .utf8),
@@ -1556,6 +1565,11 @@ struct FormSubmissionCreateView: View {
             }
         }
         
+        if field.type == "repeater", let subFields = field.subFields,
+           RepeaterMediaSupport.firstValidationIssue(in: responses[field.id], subFields: subFields) != nil {
+            return true
+        }
+        
         return false
     }
     
@@ -1585,6 +1599,16 @@ struct FormSubmissionCreateView: View {
             let value = responses[field.id] ?? ""
             if value != submissionReq.requiredValue {
                 return submissionReq.validationMessage
+            }
+        }
+        
+        if field.type == "repeater", let subFields = field.subFields,
+           let issue = RepeaterMediaSupport.firstValidationIssue(in: responses[field.id], subFields: subFields) {
+            switch issue {
+            case .missingRequired(let rowIndex, let subField):
+                return "Row \(rowIndex + 1): \(subField.label.isEmpty ? subField.id : subField.label) is required"
+            case .submissionRequirement(let rowIndex, _, let message):
+                return "Row \(rowIndex + 1): \(message)"
             }
         }
         
@@ -1639,30 +1663,10 @@ struct FormSubmissionCreateView: View {
             
             // Check repeater field requirements
             if field.type == "repeater", let subFields = field.subFields {
-                if let repeaterDataString = responses[field.id],
-                   let jsonData = repeaterDataString.data(using: .utf8),
-                   let repeaterRows = try? JSONSerialization.jsonObject(with: jsonData) as? [[String: String]] {
-                    
-                    for rowData in repeaterRows {
-                        for subField in subFields {
-                            if subField.required {
-                                let subFieldValue = rowData[subField.id] ?? ""
-                                if subFieldValue.isEmpty {
-                                    isFormValid = false
-                                    return
-                                }
-                            }
-                            
-                            if let submissionReq = subField.submissionRequirement,
-                               submissionReq.requiredForSubmission {
-                                let subFieldValue = rowData[subField.id] ?? ""
-                                if subFieldValue.lowercased() != submissionReq.requiredValue.lowercased() {
-                                    isFormValid = false
-                                    return
-                                }
-                            }
-                        }
-                    }
+                if RepeaterMediaSupport.firstValidationIssue(in: responses[field.id], subFields: subFields) != nil {
+                    print("❌ [Validation] Failed: Repeater field \(field.id) has incomplete required subfields")
+                    isFormValid = false
+                    return
                 }
             }
             

--- a/SiteSinc/Forms/FormSubmissionDetailView.swift
+++ b/SiteSinc/Forms/FormSubmissionDetailView.swift
@@ -2504,7 +2504,7 @@ struct ModernRepeaterContent: View {
         // Check if this field is an image type based on the subFields
         if let subFields = field.subFields,
            let subField = subFields.first(where: { $0.id == fieldKey }) {
-            let imageTypes = ["signature", "image", "camera", "attachment"]
+            let imageTypes = ["signature", "image", "camera", "attachment", "photo"]
             return imageTypes.contains { subField.type.lowercased().contains($0) }
         }
         return false
@@ -2513,9 +2513,14 @@ struct ModernRepeaterContent: View {
     private func isImageValue(_ value: FormResponseValue) -> Bool {
         switch value {
         case .string(let str):
-            return str.hasPrefix("data:image/") || str.contains("http") || str.contains("amazonaws") || str.contains("sitesinc")
+            return RepeaterMediaSupport.isLocalImagePayload(str)
+                || RepeaterMediaSupport.looksLikeImageRef(str)
         case .stringArray(let arr):
-            return arr.contains { $0.hasPrefix("data:image/") || $0.contains("http") }
+            return arr.contains {
+                RepeaterMediaSupport.isLocalImagePayload($0) || RepeaterMediaSupport.looksLikeImageRef($0)
+            }
+        case .camera, .cameraArray:
+            return true
         default:
             return false
         }
@@ -2523,7 +2528,23 @@ struct ModernRepeaterContent: View {
     
     @ViewBuilder
     private func imageDisplayView(for value: FormResponseValue) -> some View {
-        if let urls = getImageURLs(from: value), !urls.isEmpty {
+        let urls = getImageURLs(from: value) ?? []
+        let dataImages = getDataImages(from: value)
+        if !dataImages.isEmpty {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 4) {
+                    ForEach(Array(dataImages.enumerated()), id: \.offset) { _, image in
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 60)
+                            .frame(maxWidth: 120)
+                            .background(Color.gray.opacity(0.1))
+                            .cornerRadius(8)
+                    }
+                }
+            }
+        } else if !urls.isEmpty {
             if urls.count == 1 {
                 singleImageView(urls: urls)
             } else {
@@ -2597,25 +2618,30 @@ struct ModernRepeaterContent: View {
     }
     
     private func getImageURLs(from value: FormResponseValue) -> [URL]? {
+        let refs = imageRefs(from: value).filter { !RepeaterMediaSupport.isLocalImagePayload($0) }
+        let urls = refs.compactMap { URL(string: $0) }.filter { $0.scheme == "http" || $0.scheme == "https" }
+        return urls.isEmpty ? nil : urls
+    }
+    
+    private func getDataImages(from value: FormResponseValue) -> [UIImage] {
+        imageRefs(from: value).compactMap { RepeaterMediaSupport.uiImage(fromStoredImage: $0) }
+    }
+    
+    private func imageRefs(from value: FormResponseValue) -> [String] {
         switch value {
         case .string(let str):
-            if str.hasPrefix("data:image/") {
-                // Handle base64 image
-                return [URL(string: str)].compactMap { $0 }
-            } else if let url = URL(string: str) {
-                return [url]
+            if let obj = RepeaterMediaSupport.jsonObject(from: str) {
+                return RepeaterMediaSupport.parseImageRefs(obj)
             }
-            return nil
+            return RepeaterMediaSupport.isEmptyValue(str) ? [] : [str]
         case .stringArray(let arr):
-            return arr.compactMap { urlString in
-                if urlString.hasPrefix("data:image/") {
-                    return URL(string: urlString)
-                } else {
-                    return URL(string: urlString)
-                }
-            }
+            return arr
+        case .camera(let cameraData):
+            return [cameraData.image]
+        case .cameraArray(let cameraArray):
+            return cameraArray.map(\.image)
         default:
-            return nil
+            return []
         }
     }
     

--- a/SiteSinc/Forms/FormSubmissionEditView.swift
+++ b/SiteSinc/Forms/FormSubmissionEditView.swift
@@ -942,7 +942,19 @@ struct FormSubmissionEditView: View {
                 // Convert repeater and table field strings back to JSON arrays for submission
                 if let fields = form.currentRevision?.fields {
                     for field in fields {
-                        if field.type == "repeater" || field.type == "table" {
+                        if field.type == "repeater" {
+                            if let value = processedFormData[field.id] as? String {
+                                processedFormData[field.id] = try await RepeaterMediaSupport.rewriteRowsForSubmission(
+                                    RepeaterMediaSupport.parseRows(from: value),
+                                    subFields: field.subFields ?? [],
+                                    parentFieldId: field.id,
+                                    uploadJPEG: { jpeg, fileName in
+                                        try await self.uploadFileDataAsync(jpeg, fileName: fileName, fieldId: field.id, mimeType: "image/jpeg")
+                                    },
+                                    fileKeyFromRef: { RepeaterMediaSupport.fileKey(from: $0) }
+                                )
+                            }
+                        } else if field.type == "table" {
                             if let value = processedFormData[field.id] as? String,
                                let data = value.data(using: .utf8),
                                let jsonArray = try? JSONSerialization.jsonObject(with: data) {
@@ -1321,29 +1333,12 @@ struct FormSubmissionEditView: View {
             
             // Validate repeater field subfields
             if field.type == "repeater", let subFields = field.subFields {
-                // Get repeater data for this field
-                if let repeaterDataString = responses[field.id],
-                   let jsonData = repeaterDataString.data(using: .utf8),
-                   let repeaterRows = try? JSONSerialization.jsonObject(with: jsonData) as? [[String: String]] {
-                    
-                    for (rowIndex, rowData) in repeaterRows.enumerated() {
-                        for subField in subFields {
-                            if subField.required {
-                                let subFieldValue = rowData[subField.id] ?? ""
-                                if subFieldValue.isEmpty {
-                                    return "Please fill in the required field in row \(rowIndex + 1): \(subField.label.isEmpty ? subField.id : subField.label)"
-                                }
-                            }
-                            
-                            // Check subfield submission requirements
-                            if let submissionReq = subField.submissionRequirement,
-                               submissionReq.requiredForSubmission {
-                                let subFieldValue = rowData[subField.id] ?? ""
-                                if subFieldValue != submissionReq.requiredValue {
-                                    return "Row \(rowIndex + 1): \(submissionReq.validationMessage)"
-                                }
-                            }
-                        }
+                if let issue = RepeaterMediaSupport.firstValidationIssue(in: responses[field.id], subFields: subFields) {
+                    switch issue {
+                    case .missingRequired(let rowIndex, let subField):
+                        return "Please fill in the required field in row \(rowIndex + 1): \(subField.label.isEmpty ? subField.id : subField.label)"
+                    case .submissionRequirement(let rowIndex, _, let message):
+                        return "Row \(rowIndex + 1): \(message)"
                     }
                 }
             }
@@ -1375,6 +1370,11 @@ struct FormSubmissionEditView: View {
             }
         }
         
+        if field.type == "repeater", let subFields = field.subFields,
+           RepeaterMediaSupport.firstValidationIssue(in: responses[field.id], subFields: subFields) != nil {
+            return true
+        }
+        
         return false
     }
     
@@ -1398,6 +1398,16 @@ struct FormSubmissionEditView: View {
             let value = responses[field.id] ?? ""
             if value != submissionReq.requiredValue {
                 return submissionReq.validationMessage
+            }
+        }
+        
+        if field.type == "repeater", let subFields = field.subFields,
+           let issue = RepeaterMediaSupport.firstValidationIssue(in: responses[field.id], subFields: subFields) {
+            switch issue {
+            case .missingRequired(let rowIndex, let subField):
+                return "Row \(rowIndex + 1): \(subField.label.isEmpty ? subField.id : subField.label) is required"
+            case .submissionRequirement(let rowIndex, _, let message):
+                return "Row \(rowIndex + 1): \(message)"
             }
         }
         
@@ -1446,30 +1456,9 @@ struct FormSubmissionEditView: View {
             
             // Check repeater field requirements
             if field.type == "repeater", let subFields = field.subFields {
-                if let repeaterDataString = responses[field.id],
-                   let jsonData = repeaterDataString.data(using: .utf8),
-                   let repeaterRows = try? JSONSerialization.jsonObject(with: jsonData) as? [[String: String]] {
-                    
-                    for rowData in repeaterRows {
-                        for subField in subFields {
-                            if subField.required {
-                                let subFieldValue = rowData[subField.id] ?? ""
-                                if subFieldValue.isEmpty {
-                                    isFormValid = false
-                                    return
-                                }
-                            }
-                            
-                            if let submissionReq = subField.submissionRequirement,
-                               submissionReq.requiredForSubmission {
-                                let subFieldValue = rowData[subField.id] ?? ""
-                                if subFieldValue.lowercased() != submissionReq.requiredValue.lowercased() {
-                                    isFormValid = false
-                                    return
-                                }
-                            }
-                        }
-                    }
+                if RepeaterMediaSupport.firstValidationIssue(in: responses[field.id], subFields: subFields) != nil {
+                    isFormValid = false
+                    return
                 }
             }
             

--- a/SiteSinc/Forms/RepeaterFieldView.swift
+++ b/SiteSinc/Forms/RepeaterFieldView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+import PhotosUI
+import AVFoundation
+import CoreLocation
 
 // MARK: - RepeaterFieldView
 struct RepeaterFieldView: View {
@@ -8,6 +11,20 @@ struct RepeaterFieldView: View {
     @State private var repeaterData: [[String: String]] = []
     @State private var showingSignaturePad: String? // fieldId_rowIndex format
     @State private var signatureImages: [String: UIImage] = [:] // fieldId_rowIndex -> UIImage
+    @State private var mediaItems: [String: [RepeaterMediaItem]] = [:]
+    @State private var photoPreviews: [String: [UIImage]] = [:]
+    
+    @State private var activeMediaKey: String?
+    @State private var showingPhotosPicker = false
+    @State private var pickerSelection: [PhotosPickerItem] = []
+    @State private var showingCameraActionSheetForKey: String?
+    @State private var isCustomCameraPresented = false
+    @State private var cameraSessionPhotos: [PhotoWithLocation] = []
+    @State private var showingPermissionAlert = false
+    @State private var permissionAlertMessage = ""
+    
+    @State private var photoMarkupPresentation: PhotoMarkupPresentationItem?
+    @State private var photoMarkupTarget: (key: String, index: Int)?
     
     private var minItems: Int { field.minItems ?? 0 }
     private var maxItems: Int { field.maxItems ?? 10 }
@@ -47,6 +64,61 @@ struct RepeaterFieldView: View {
         .sheet(isPresented: isSheetPresented) {
             signaturePadSheet
         }
+        .photosPicker(
+            isPresented: $showingPhotosPicker,
+            selection: $pickerSelection,
+            maxSelectionCount: remainingPhotoSlots(for: activeMediaKey),
+            matching: .images
+        )
+        .onChange(of: pickerSelection) { _, newItems in
+            handlePickerSelection(newItems)
+        }
+        .confirmationDialog(
+            "Add Image",
+            isPresented: Binding(
+                get: { showingCameraActionSheetForKey != nil },
+                set: { if !$0 { showingCameraActionSheetForKey = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Take Photo") {
+                requestCameraAndPresent()
+            }
+            Button("Choose From Library") {
+                activeMediaKey = showingCameraActionSheetForKey ?? activeMediaKey
+                showingPhotosPicker = true
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Take new photos or pick from your library.")
+        }
+        .fullScreenCover(isPresented: $isCustomCameraPresented, onDismiss: {
+            cameraSessionPhotos = []
+        }) {
+            CustomCameraView(capturedImages: $cameraSessionPhotos)
+        }
+        .onChange(of: cameraSessionPhotos) { oldValue, newValue in
+            let added = Array(newValue.dropFirst(oldValue.count))
+            guard !added.isEmpty, let key = activeMediaKey else { return }
+            appendPhotos(added, to: key)
+        }
+        .fullScreenCover(item: $photoMarkupPresentation) { item in
+            PhotoMarkupEditorScreen(
+                image: item.image,
+                onDone: { data in
+                    applyMarkup(data)
+                },
+                onCancel: {
+                    photoMarkupPresentation = nil
+                    photoMarkupTarget = nil
+                }
+            )
+        }
+        .alert("Camera Permission", isPresented: $showingPermissionAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(permissionAlertMessage)
+        }
     }
     
     @ViewBuilder
@@ -61,7 +133,7 @@ struct RepeaterFieldView: View {
     
     @ViewBuilder
     private var itemsList: some View {
-        ForEach(Array(repeaterData.enumerated()), id: \.offset) { index, item in
+        ForEach(Array(repeaterData.enumerated()), id: \.offset) { index, _ in
             VStack(alignment: .leading, spacing: 12) {
                 HStack {
                     Text("\(field.label) #\(index + 1)")
@@ -149,20 +221,21 @@ struct RepeaterFieldView: View {
     
     private func loadExistingData() {
         if let existingJson = responses[field.id], !existingJson.isEmpty {
-            if let data = existingJson.data(using: .utf8),
-               let decoded = try? JSONDecoder().decode([[String: String]].self, from: data) {
-                repeaterData = decoded
+            let decodedRows = RepeaterMediaSupport.rowsAsStringDicts(from: existingJson)
+            if !decodedRows.isEmpty {
+                repeaterData = decodedRows
                 
-                // Load existing signatures into signatureImages
-                for (rowIndex, rowData) in decoded.enumerated() {
+                for (rowIndex, rowData) in decodedRows.enumerated() {
                     if let subFields = field.subFields {
-                        for subField in subFields where subField.type == "signature" {
-                            if let base64String = rowData[subField.id], !base64String.isEmpty {
-                                // Convert base64 back to UIImage
-                                if let image = base64ToUIImage(base64String) {
-                                    let signatureKey = "\(subField.id)_\(rowIndex)"
+                        for subField in subFields {
+                            if subField.type == "signature" {
+                                if let base64String = rowData[subField.id], !base64String.isEmpty,
+                                   let image = base64ToUIImage(base64String) {
+                                    let signatureKey = RepeaterMediaSupport.mediaKey(fieldId: subField.id, rowIndex: rowIndex)
                                     signatureImages[signatureKey] = image
                                 }
+                            } else if RepeaterMediaSupport.mediaFieldTypes.contains(subField.type) {
+                                loadMedia(for: subField, rowIndex: rowIndex, stored: rowData[subField.id] ?? "")
                             }
                         }
                     }
@@ -176,30 +249,43 @@ struct RepeaterFieldView: View {
         }
     }
     
-    private func base64ToUIImage(_ base64String: String) -> UIImage? {
-        // Handle both "data:image/jpeg;base64,..." and plain base64 formats
-        let base64Data: String
-        if base64String.hasPrefix("data:image/") {
-            guard let range = base64String.range(of: ";base64,") else { return nil }
-            base64Data = String(base64String[range.upperBound...])
-        } else {
-            base64Data = base64String
+    private func loadMedia(for subField: FormField, rowIndex: Int, stored: String) {
+        let key = RepeaterMediaSupport.mediaKey(fieldId: subField.id, rowIndex: rowIndex)
+        let isCamera = RepeaterMediaSupport.isCameraType(subField.type)
+        let items = RepeaterMediaSupport.mediaItems(fromStoredValue: stored, isCamera: isCamera)
+        mediaItems[key] = items
+        var previews: [UIImage] = []
+        for item in items {
+            if let data = item.jpegData, let image = UIImage(data: data) {
+                previews.append(image.thumbnail(maxPixelSize: 400))
+            } else {
+                previews.append(UIImage())
+            }
         }
-        
-        guard let data = Data(base64Encoded: base64Data) else { return nil }
-        return UIImage(data: data)
+        photoPreviews[key] = previews
+        Task {
+            var updated = previews
+            for (index, item) in items.enumerated() {
+                if item.jpegData != nil { continue }
+                guard let ref = item.remoteRef, let url = URL(string: ref), url.scheme?.hasPrefix("http") == true else { continue }
+                if let (data, _) = try? await URLSession.shared.data(from: url),
+                   let image = UIImage(data: data) {
+                    updated[index] = image.thumbnail(maxPixelSize: 400)
+                }
+            }
+            await MainActor.run {
+                photoPreviews[key] = updated
+            }
+        }
+    }
+    
+    private func base64ToUIImage(_ base64String: String) -> UIImage? {
+        RepeaterMediaSupport.uiImage(fromStoredImage: base64String)
     }
     
     private func saveRepeaterData() {
-        // Store as JSON array structure that matches frontend format
-        // Convert [[String: String]] to JSON array string that can be parsed by frontend
-        do {
-            let jsonData = try JSONEncoder().encode(repeaterData)
-            if let jsonString = String(data: jsonData, encoding: .utf8) {
-                responses[field.id] = jsonString
-            }
-        } catch {
-            print("Failed to encode repeater data: \(error)")
+        if let jsonString = RepeaterMediaSupport.encodeRows(repeaterData, subFields: field.subFields ?? []) {
+            responses[field.id] = jsonString
         }
     }
     
@@ -217,23 +303,156 @@ struct RepeaterFieldView: View {
     private func removeItem(at index: Int) {
         guard index < repeaterData.count, repeaterData.count > minItems else { return }
         repeaterData.remove(at: index)
+        reindexKeyedState(removedIndex: index)
+    }
+    
+    private func reindexKeyedState(removedIndex: Int) {
+        signatureImages = reindexDictionary(signatureImages, removedIndex: removedIndex)
+        mediaItems = reindexDictionary(mediaItems, removedIndex: removedIndex)
+        photoPreviews = reindexDictionary(photoPreviews, removedIndex: removedIndex)
+        if let pad = showingSignaturePad, let parsed = RepeaterMediaSupport.parseMediaKey(pad), parsed.rowIndex == removedIndex {
+            showingSignaturePad = nil
+        }
+        if let key = activeMediaKey, let parsed = RepeaterMediaSupport.parseMediaKey(key), parsed.rowIndex == removedIndex {
+            activeMediaKey = nil
+        }
+    }
+    
+    private func reindexDictionary<Value>(_ dict: [String: Value], removedIndex: Int) -> [String: Value] {
+        var result: [String: Value] = [:]
+        for (key, value) in dict {
+            guard let parsed = RepeaterMediaSupport.parseMediaKey(key) else { continue }
+            if parsed.rowIndex == removedIndex { continue }
+            let newIndex = parsed.rowIndex > removedIndex ? parsed.rowIndex - 1 : parsed.rowIndex
+            result[RepeaterMediaSupport.mediaKey(fieldId: parsed.fieldId, rowIndex: newIndex)] = value
+        }
+        return result
     }
     
     private func updateSignatureInRepeaterData(fieldKey: String, signature: String) {
-        let components = fieldKey.split(separator: "_")
-        
-        guard components.count >= 2,
-              let rowIndex = Int(components.last!) else { 
-            return 
+        guard let parsed = RepeaterMediaSupport.parseMediaKey(fieldKey),
+              parsed.rowIndex < repeaterData.count else {
+            return
         }
-        
-        // Field ID is everything except the last component (row index)
-        let fieldIdComponents = components.dropLast()
-        let fieldId = fieldIdComponents.joined(separator: "_")
-        
-        if rowIndex < repeaterData.count {
-            repeaterData[rowIndex][fieldId] = signature
+        repeaterData[parsed.rowIndex][parsed.fieldId] = signature
+    }
+    
+    // MARK: - Media helpers
+    
+    private func remainingPhotoSlots(for key: String?) -> Int {
+        let current = key.flatMap { mediaItems[$0]?.count } ?? 0
+        return max(1, RepeaterMediaSupport.maxPhotosPerField - current)
+    }
+    
+    private func persistMedia(for key: String) {
+        guard let parsed = RepeaterMediaSupport.parseMediaKey(key),
+              parsed.rowIndex < repeaterData.count else { return }
+        let items = mediaItems[key] ?? []
+        let subType = field.subFields?.first(where: { $0.id == parsed.fieldId })?.type ?? "image"
+        if RepeaterMediaSupport.isCameraType(subType) {
+            repeaterData[parsed.rowIndex][parsed.fieldId] = RepeaterMediaSupport.encodeCameraItems(items)
+        } else {
+            repeaterData[parsed.rowIndex][parsed.fieldId] = RepeaterMediaSupport.encodeImageItems(items)
         }
+    }
+    
+    private func appendItems(_ newItems: [RepeaterMediaItem], to key: String) {
+        var existing = mediaItems[key] ?? []
+        let room = RepeaterMediaSupport.maxPhotosPerField - existing.count
+        guard room > 0 else { return }
+        let toAdd = Array(newItems.prefix(room))
+        existing.append(contentsOf: toAdd)
+        mediaItems[key] = existing
+        var previews = photoPreviews[key] ?? []
+        for item in toAdd {
+            if let data = item.jpegData, let image = UIImage(data: data) {
+                previews.append(image.thumbnail(maxPixelSize: 400))
+            }
+        }
+        photoPreviews[key] = previews
+        persistMedia(for: key)
+    }
+    
+    private func appendPhotos(_ photos: [PhotoWithLocation], to key: String) {
+        appendItems(photos.map { RepeaterMediaSupport.item(from: $0) }, to: key)
+    }
+    
+    private func removeMedia(at index: Int, key: String) {
+        guard var items = mediaItems[key], index < items.count else { return }
+        items.remove(at: index)
+        mediaItems[key] = items
+        if var previews = photoPreviews[key], index < previews.count {
+            previews.remove(at: index)
+            photoPreviews[key] = previews
+        }
+        persistMedia(for: key)
+    }
+    
+    private func handlePickerSelection(_ newItems: [PhotosPickerItem]) {
+        guard let key = activeMediaKey, !newItems.isEmpty else {
+            if newItems.isEmpty { activeMediaKey = nil }
+            return
+        }
+        Task {
+            var loaded: [RepeaterMediaItem] = []
+            for item in newItems {
+                if let data = try? await item.loadTransferable(type: Data.self) {
+                    let jpeg = UIImage(data: data)?.jpegData(compressionQuality: 0.8) ?? data
+                    loaded.append(RepeaterMediaSupport.item(fromJPEG: jpeg))
+                }
+            }
+            await MainActor.run {
+                appendItems(loaded, to: key)
+                pickerSelection = []
+                activeMediaKey = nil
+            }
+        }
+    }
+    
+    private func requestCameraAndPresent() {
+        let key = showingCameraActionSheetForKey ?? activeMediaKey
+        activeMediaKey = key
+        let status = AVCaptureDevice.authorizationStatus(for: .video)
+        if status == .authorized {
+            isCustomCameraPresented = true
+        } else if status == .notDetermined {
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                DispatchQueue.main.async {
+                    if granted {
+                        self.isCustomCameraPresented = true
+                    }
+                }
+            }
+        } else {
+            permissionAlertMessage = "Camera access is required. Enable it in Settings."
+            showingPermissionAlert = true
+        }
+    }
+    
+    private func openMarkupEditor(key: String, index: Int) {
+        guard let items = mediaItems[key], index < items.count,
+              let data = items[index].jpegData, let image = UIImage(data: data) else { return }
+        photoMarkupTarget = (key, index)
+        photoMarkupPresentation = PhotoMarkupPresentationItem(image: image)
+    }
+    
+    private func applyMarkup(_ data: Data) {
+        guard let target = photoMarkupTarget else { return }
+        guard var items = mediaItems[target.key], target.index < items.count else {
+            photoMarkupPresentation = nil
+            photoMarkupTarget = nil
+            return
+        }
+        items[target.index].jpegData = data
+        items[target.index].remoteRef = nil
+        mediaItems[target.key] = items
+        if var previews = photoPreviews[target.key], target.index < previews.count, let image = UIImage(data: data) {
+            previews[target.index] = image.thumbnail(maxPixelSize: 400)
+            photoPreviews[target.key] = previews
+        }
+        persistMedia(for: target.key)
+        photoMarkupPresentation = nil
+        photoMarkupTarget = nil
     }
     
     @ViewBuilder
@@ -252,7 +471,7 @@ struct RepeaterFieldView: View {
                 // Show validation status for required fields
                 if subField.required {
                     let currentValue = repeaterData[safe: rowIndex]?[subField.id] ?? ""
-                    let isEmpty = currentValue.isEmpty || currentValue == ""
+                    let isEmpty = RepeaterMediaSupport.isEmptyValue(currentValue)
                     
                     if isEmpty {
                         Image(systemName: "exclamationmark.circle.fill")
@@ -363,7 +582,7 @@ struct RepeaterFieldView: View {
                 }
                 
             case "signature":
-                let signatureKey = "\(subField.id)_\(rowIndex)"
+                let signatureKey = RepeaterMediaSupport.mediaKey(fieldId: subField.id, rowIndex: rowIndex)
                 VStack(alignment: .leading, spacing: 8) {
                     // Show existing signature if available
                     if let signatureImage = signatureImages[signatureKey] {
@@ -432,29 +651,8 @@ struct RepeaterFieldView: View {
                     }
                 }
                 
-            case "image", "camera":
-                VStack(alignment: .leading, spacing: 8) {
-                    // Note: Image/Camera functionality for repeater fields is not yet implemented
-                    // This would require complex state management similar to signature fields
-                    Button(action: {
-                        // TODO: Implement image selection/camera capture for repeater fields
-                    }) {
-                        HStack {
-                            Image(systemName: subField.type == "camera" ? "camera" : "photo")
-                            Text(subField.type == "camera" ? "Take Photo" : "Select Image")
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.gray.opacity(0.1))
-                        .foregroundColor(.gray)
-                        .cornerRadius(8)
-                    }
-                    .disabled(true)
-                    
-                    Text("Image/Camera fields in repeaters coming soon")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
+            case "image", "camera", "photo":
+                repeaterMediaEditor(subField: subField, rowIndex: rowIndex)
                 
             case "attachment":
                 VStack(alignment: .leading, spacing: 8) {
@@ -492,6 +690,95 @@ struct RepeaterFieldView: View {
             }
         }
     }
+    
+    @ViewBuilder
+    private func repeaterMediaEditor(subField: FormField, rowIndex: Int) -> some View {
+        let key = RepeaterMediaSupport.mediaKey(fieldId: subField.id, rowIndex: rowIndex)
+        let isCamera = RepeaterMediaSupport.isCameraType(subField.type)
+        let items = mediaItems[key] ?? []
+        let previews = photoPreviews[key] ?? []
+        let canAddMore = items.count < RepeaterMediaSupport.maxPhotosPerField
+        
+        VStack(alignment: .leading, spacing: 8) {
+            if !items.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 12) {
+                        ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                            ZStack(alignment: .topTrailing) {
+                                if index < previews.count, previews[index].size.width > 1 {
+                                    Image(uiImage: previews[index])
+                                        .resizable()
+                                        .scaledToFit()
+                                        .frame(height: 100)
+                                        .cornerRadius(8)
+                                } else {
+                                    ProgressView()
+                                        .frame(width: 100, height: 100)
+                                        .background(Color.gray.opacity(0.15))
+                                        .cornerRadius(8)
+                                }
+                                
+                                if isCamera, item.jpegData != nil {
+                                    VStack {
+                                        Spacer()
+                                        HStack {
+                                            Button {
+                                                openMarkupEditor(key: key, index: index)
+                                            } label: {
+                                                Image(systemName: "pencil.tip.crop.circle")
+                                                    .font(.system(size: 20))
+                                                    .foregroundStyle(.white)
+                                                    .padding(6)
+                                                    .background(.ultraThinMaterial, in: Circle())
+                                            }
+                                            .accessibilityLabel("Mark up photo")
+                                            Spacer()
+                                        }
+                                    }
+                                    .padding(4)
+                                }
+                                
+                                Button(action: {
+                                    removeMedia(at: index, key: key)
+                                }) {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .font(.system(size: 22))
+                                        .foregroundColor(.white)
+                                        .background(Color.black.opacity(0.6))
+                                        .clipShape(Circle())
+                                }
+                                .padding(4)
+                            }
+                            .frame(height: 100)
+                        }
+                    }
+                    .padding(.horizontal, 4)
+                }
+            }
+            
+            if canAddMore {
+                if isCamera {
+                    Button(action: {
+                        activeMediaKey = key
+                        showingCameraActionSheetForKey = key
+                    }) {
+                        Label("Add Image(s)", systemImage: "photo.on.rectangle.angled")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                } else {
+                    Button(action: {
+                        activeMediaKey = key
+                        showingPhotosPicker = true
+                    }) {
+                        Label("Select Images", systemImage: "photo")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+        }
+    }
 }
 
 // Safe array access extension
@@ -511,4 +798,4 @@ struct IdentifiableString: Identifiable {
     }
 }
 
-// Note: SignaturePadView and IdentifiablePath are defined in FormSubmissionCreateView.swift 
+// Note: SignaturePadView and IdentifiablePath are defined in FormSubmissionCreateView.swift

--- a/SiteSinc/Forms/RepeaterFieldView.swift
+++ b/SiteSinc/Forms/RepeaterFieldView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import PhotosUI
 import AVFoundation
-import CoreLocation
 
 // MARK: - RepeaterFieldView
 struct RepeaterFieldView: View {

--- a/SiteSinc/Forms/RepeaterMediaSupport.swift
+++ b/SiteSinc/Forms/RepeaterMediaSupport.swift
@@ -1,0 +1,469 @@
+import Foundation
+import CoreLocation
+import UIKit
+
+/// Local representation of a photo stored on a repeater image/camera sub-field.
+struct RepeaterMediaItem: Identifiable, Equatable {
+    let id: UUID
+    /// Fresh JPEG bytes that still need uploading.
+    var jpegData: Data?
+    /// Existing remote URL or file key (already uploaded).
+    var remoteRef: String?
+    var capturedAt: Date?
+    var latitude: Double?
+    var longitude: Double?
+    var accuracy: Double?
+    var locationTimestamp: Double?
+
+    init(
+        id: UUID = UUID(),
+        jpegData: Data? = nil,
+        remoteRef: String? = nil,
+        capturedAt: Date? = nil,
+        latitude: Double? = nil,
+        longitude: Double? = nil,
+        accuracy: Double? = nil,
+        locationTimestamp: Double? = nil
+    ) {
+        self.id = id
+        self.jpegData = jpegData
+        self.remoteRef = remoteRef
+        self.capturedAt = capturedAt
+        self.latitude = latitude
+        self.longitude = longitude
+        self.accuracy = accuracy
+        self.locationTimestamp = locationTimestamp
+    }
+
+    var storedImageValue: String {
+        if let jpegData, !jpegData.isEmpty {
+            return RepeaterMediaSupport.dataURL(fromJPEG: jpegData)
+        }
+        return remoteRef ?? ""
+    }
+
+    var hasImage: Bool {
+        (jpegData != nil && !(jpegData?.isEmpty ?? true)) || !(remoteRef?.isEmpty ?? true)
+    }
+}
+
+enum RepeaterMediaSupport {
+    static let maxPhotosPerField = 5
+    static let mediaFieldTypes: Set<String> = ["image", "camera", "photo"]
+
+    // MARK: - Data URLs
+
+    static func dataURL(fromJPEG data: Data) -> String {
+        "data:image/jpeg;base64,\(data.base64EncodedString())"
+    }
+
+    static func jpegData(fromStoredImage string: String) -> Data? {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("data:image/") else { return nil }
+        guard let range = trimmed.range(of: ";base64,") else { return nil }
+        return Data(base64Encoded: String(trimmed[range.upperBound...]))
+    }
+
+    static func uiImage(fromStoredImage string: String) -> UIImage? {
+        if let data = jpegData(fromStoredImage: string) {
+            return UIImage(data: data)
+        }
+        return nil
+    }
+
+    static func isLocalImagePayload(_ string: String) -> Bool {
+        string.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("data:image/")
+    }
+
+    // MARK: - Repeater JSON
+
+    static func parseRows(from jsonString: String) -> [[String: Any]] {
+        guard let data = jsonString.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) else {
+            return []
+        }
+        return parseRows(fromJSONObject: obj)
+    }
+
+    static func parseRows(fromJSONObject obj: Any) -> [[String: Any]] {
+        if let rows = obj as? [[String: Any]] {
+            return rows
+        }
+        if let arr = obj as? [Any] {
+            return arr.compactMap { $0 as? [String: Any] }
+        }
+        return []
+    }
+
+    static func stringifyValue(_ value: Any) -> String {
+        if value is NSNull {
+            return ""
+        }
+        if let s = value as? String {
+            return s
+        }
+        if let n = value as? NSNumber {
+            if CFGetTypeID(n) == CFBooleanGetTypeID() {
+                return n.boolValue ? "true" : "false"
+            }
+            return n.stringValue
+        }
+        if JSONSerialization.isValidJSONObject(value),
+           let data = try? JSONSerialization.data(withJSONObject: value, options: []),
+           let s = String(data: data, encoding: .utf8) {
+            return s
+        }
+        return "\(value)"
+    }
+
+    static func isEmptyValue(_ value: Any?) -> Bool {
+        guard let value else { return true }
+        if value is NSNull { return true }
+        if let s = value as? String {
+            let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty || trimmed == "[]" || trimmed == "{}" || trimmed == "null"
+        }
+        if let arr = value as? [Any] {
+            return arr.isEmpty
+        }
+        if let dict = value as? [String: Any] {
+            if let image = dict["image"] as? String {
+                return image.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }
+            return dict.isEmpty
+        }
+        return false
+    }
+
+    static func scalarString(_ value: Any?) -> String {
+        guard let value else { return "" }
+        if let s = value as? String { return s }
+        if let n = value as? NSNumber { return n.stringValue }
+        return ""
+    }
+
+    /// Turns internally stored string cells (including JSON blobs) into typed JSON for the API.
+    static func expandRowsForStorage(_ rows: [[String: String]], subFields: [FormField]) -> [[String: Any]] {
+        let mediaIds = Set(subFields.filter { mediaFieldTypes.contains($0.type) }.map(\.id))
+        return rows.map { row in
+            var out: [String: Any] = [:]
+            for (key, value) in row {
+                if mediaIds.contains(key), let parsed = jsonObject(from: value) {
+                    out[key] = parsed
+                } else {
+                    out[key] = value
+                }
+            }
+            return out
+        }
+    }
+
+    static func encodeRows(_ rows: [[String: String]], subFields: [FormField]) -> String? {
+        let expanded = expandRowsForStorage(rows, subFields: subFields)
+        guard JSONSerialization.isValidJSONObject(expanded),
+              let data = try? JSONSerialization.data(withJSONObject: expanded, options: []),
+              let json = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return json
+    }
+
+    static func rowsAsStringDicts(from jsonString: String) -> [[String: String]] {
+        parseRows(from: jsonString).map { row in
+            Dictionary(uniqueKeysWithValues: row.map { ($0.key, stringifyValue($0.value)) })
+        }
+    }
+
+    static func jsonObject(from string: String) -> Any? {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("[") || trimmed.hasPrefix("{") else { return nil }
+        guard let data = trimmed.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data)
+    }
+
+    // MARK: - Image / camera cell parsing
+
+    static func parseImageRefs(_ value: Any) -> [String] {
+        if let s = value as? String {
+            if isEmptyValue(s) { return [] }
+            if let obj = jsonObject(from: s) {
+                return parseImageRefs(obj)
+            }
+            return [s]
+        }
+        if let arr = value as? [String] {
+            return arr.filter { !isEmptyValue($0) }
+        }
+        if let arr = value as? [Any] {
+            return arr.compactMap { item -> String? in
+                if let s = item as? String, !isEmptyValue(s) { return s }
+                if let d = item as? [String: Any], let image = d["image"] as? String, !isEmptyValue(image) {
+                    return image
+                }
+                return nil
+            }
+        }
+        if let d = value as? [String: Any], let image = d["image"] as? String, !isEmptyValue(image) {
+            return [image]
+        }
+        return []
+    }
+
+    static func parseCameraDicts(_ value: Any) -> [[String: Any]] {
+        if let s = value as? String {
+            if isEmptyValue(s) { return [] }
+            if let obj = jsonObject(from: s) {
+                return parseCameraDicts(obj)
+            }
+            if isLocalImagePayload(s) || looksLikeImageRef(s) {
+                return [["image": s]]
+            }
+            return []
+        }
+        if let dict = value as? [String: Any], dict["image"] != nil {
+            return [dict]
+        }
+        if let arr = value as? [Any] {
+            return arr.compactMap { item -> [String: Any]? in
+                if let d = item as? [String: Any], d["image"] != nil {
+                    return d
+                }
+                if let s = item as? String, !isEmptyValue(s) {
+                    return ["image": s]
+                }
+                return nil
+            }
+        }
+        return []
+    }
+
+    static func mediaItems(fromStoredValue value: Any, isCamera: Bool) -> [RepeaterMediaItem] {
+        if isCamera {
+            return parseCameraDicts(value).compactMap { dict in
+                guard let image = dict["image"] as? String, !isEmptyValue(image) else { return nil }
+                var item = RepeaterMediaItem()
+                applyImageRef(image, to: &item)
+                item.capturedAt = parseDate(dict["capturedAt"])
+                if let loc = dict["location"] as? [String: Any] {
+                    item.latitude = (loc["latitude"] as? NSNumber)?.doubleValue ?? loc["latitude"] as? Double
+                    item.longitude = (loc["longitude"] as? NSNumber)?.doubleValue ?? loc["longitude"] as? Double
+                    item.accuracy = (loc["accuracy"] as? NSNumber)?.doubleValue ?? loc["accuracy"] as? Double
+                    item.locationTimestamp = (loc["timestamp"] as? NSNumber)?.doubleValue ?? loc["timestamp"] as? Double
+                }
+                return item
+            }
+        }
+        return parseImageRefs(value).compactMap { ref in
+            guard !isEmptyValue(ref) else { return nil }
+            var item = RepeaterMediaItem()
+            applyImageRef(ref, to: &item)
+            return item
+        }
+    }
+
+    static func encodeImageItems(_ items: [RepeaterMediaItem]) -> String {
+        let refs = items.map(\.storedImageValue).filter { !$0.isEmpty }
+        if refs.isEmpty { return "" }
+        if refs.count == 1 { return refs[0] }
+        guard JSONSerialization.isValidJSONObject(refs),
+              let data = try? JSONSerialization.data(withJSONObject: refs, options: []),
+              let json = String(data: data, encoding: .utf8) else {
+            return refs[0]
+        }
+        return json
+    }
+
+    static func encodeCameraItems(_ items: [RepeaterMediaItem]) -> String {
+        let dicts: [[String: Any]] = items.compactMap { item in
+            let image = item.storedImageValue
+            guard !image.isEmpty else { return nil }
+            var dict: [String: Any] = ["image": image]
+            if let capturedAt = item.capturedAt {
+                dict["capturedAt"] = ISO8601DateFormatter().string(from: capturedAt)
+            }
+            if let lat = item.latitude, let lon = item.longitude {
+                var loc: [String: Any] = [
+                    "latitude": lat,
+                    "longitude": lon
+                ]
+                if let accuracy = item.accuracy { loc["accuracy"] = accuracy }
+                if let ts = item.locationTimestamp { loc["timestamp"] = ts }
+                dict["location"] = loc
+            }
+            return dict
+        }
+        if dicts.isEmpty { return "" }
+        guard JSONSerialization.isValidJSONObject(dicts),
+              let data = try? JSONSerialization.data(withJSONObject: dicts, options: []),
+              let json = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        return json
+    }
+
+    static func item(from photo: PhotoWithLocation) -> RepeaterMediaItem {
+        RepeaterMediaItem(
+            jpegData: photo.image,
+            capturedAt: photo.capturedAt,
+            latitude: photo.location?.coordinate.latitude,
+            longitude: photo.location?.coordinate.longitude,
+            accuracy: photo.location?.horizontalAccuracy,
+            locationTimestamp: photo.location?.timestamp.timeIntervalSince1970
+        )
+    }
+
+    static func item(fromJPEG data: Data, capturedAt: Date = Date()) -> RepeaterMediaItem {
+        RepeaterMediaItem(jpegData: data, capturedAt: capturedAt)
+    }
+
+    // MARK: - Upload rewrite
+
+    static func rewriteRowsForSubmission(
+        _ rows: [[String: Any]],
+        subFields: [FormField],
+        parentFieldId: String,
+        uploadJPEG: (Data, String) async throws -> String,
+        fileKeyFromRef: (String) -> String
+    ) async throws -> [[String: Any]] {
+        var result: [[String: Any]] = []
+        for (rowIndex, row) in rows.enumerated() {
+            var newRow = row
+            for subField in subFields {
+                guard let raw = row[subField.id] else { continue }
+                switch subField.type {
+                case "image":
+                    var keys: [String] = []
+                    for (i, ref) in parseImageRefs(raw).enumerated() {
+                        if let data = jpegData(fromStoredImage: ref) {
+                            let name = "\(parentFieldId)-\(subField.id)-r\(rowIndex)-\(i).jpg"
+                            keys.append(try await uploadJPEG(data, name))
+                        } else if !ref.isEmpty {
+                            keys.append(fileKeyFromRef(ref))
+                        }
+                    }
+                    if keys.isEmpty {
+                        newRow[subField.id] = ""
+                    } else if keys.count == 1 {
+                        newRow[subField.id] = keys[0]
+                    } else {
+                        newRow[subField.id] = keys
+                    }
+                case "camera", "photo":
+                    var items = parseCameraDicts(raw)
+                    for i in items.indices {
+                        guard let image = items[i]["image"] as? String, !image.isEmpty else { continue }
+                        if let data = jpegData(fromStoredImage: image) {
+                            let name = "\(parentFieldId)-\(subField.id)-r\(rowIndex)-\(i).jpg"
+                            items[i]["image"] = try await uploadJPEG(data, name)
+                        } else {
+                            items[i]["image"] = fileKeyFromRef(image)
+                        }
+                    }
+                    newRow[subField.id] = items
+                default:
+                    break
+                }
+            }
+            result.append(newRow)
+        }
+        return result
+    }
+
+    static func fileKey(from ref: String) -> String {
+        let trimmed = ref.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty || isLocalImagePayload(trimmed) { return trimmed }
+        if trimmed.hasPrefix("tenants/") { return trimmed }
+
+        var working = trimmed
+        if let decoded = working.removingPercentEncoding {
+            working = decoded
+        }
+        if let url = URL(string: working) {
+            let path = url.path
+            if let range = path.range(of: "tenants/") {
+                var key = String(path[range.lowerBound...])
+                if key.hasPrefix("/") { key.removeFirst() }
+                return key
+            }
+            if url.query?.contains("AWSAccessKeyId") == true || url.query?.contains("X-Amz-Algorithm") == true {
+                var key = url.path
+                if key.hasPrefix("/") { key.removeFirst() }
+                return key
+            }
+        }
+        return trimmed
+    }
+
+    static func looksLikeImageRef(_ string: String) -> Bool {
+        let s = string.lowercased()
+        return s.hasPrefix("http")
+            || s.hasPrefix("tenants/")
+            || s.contains("amazonaws")
+            || s.contains("sitesinc")
+            || s.contains("/forms/")
+    }
+
+    static func parseMediaKey(_ key: String) -> (fieldId: String, rowIndex: Int)? {
+        let components = key.split(separator: "_")
+        guard components.count >= 2, let rowIndex = Int(components.last!) else { return nil }
+        let fieldId = components.dropLast().joined(separator: "_")
+        return (fieldId, rowIndex)
+    }
+
+    static func mediaKey(fieldId: String, rowIndex: Int) -> String {
+        "\(fieldId)_\(rowIndex)"
+    }
+
+    static func isCameraType(_ type: String) -> Bool {
+        type == "camera" || type == "photo"
+    }
+
+    // MARK: - Validation
+
+    enum RepeaterValidationIssue {
+        case missingRequired(row: Int, subField: FormField)
+        case submissionRequirement(row: Int, subField: FormField, message: String)
+    }
+
+    static func firstValidationIssue(in jsonString: String?, subFields: [FormField]) -> RepeaterValidationIssue? {
+        guard let jsonString, !jsonString.isEmpty else { return nil }
+        let rows = parseRows(from: jsonString)
+        for (index, row) in rows.enumerated() {
+            for subField in subFields {
+                if subField.required && isEmptyValue(row[subField.id]) {
+                    return .missingRequired(row: index, subField: subField)
+                }
+                if let req = subField.submissionRequirement, req.requiredForSubmission {
+                    let value = scalarString(row[subField.id])
+                    if value.lowercased() != req.requiredValue.lowercased() {
+                        return .submissionRequirement(row: index, subField: subField, message: req.validationMessage)
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Private
+
+    private static func applyImageRef(_ ref: String, to item: inout RepeaterMediaItem) {
+        if let data = jpegData(fromStoredImage: ref) {
+            item.jpegData = data
+        } else {
+            item.remoteRef = ref
+        }
+    }
+
+    private static func parseDate(_ value: Any?) -> Date? {
+        if let s = value as? String {
+            if let d = ISO8601DateFormatter().date(from: s) { return d }
+            let f = ISO8601DateFormatter()
+            f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return f.date(from: s)
+        }
+        if let n = value as? NSNumber {
+            return Date(timeIntervalSince1970: n.doubleValue)
+        }
+        return nil
+    }
+}

--- a/SiteSincTests/RepeaterMediaSupportTests.swift
+++ b/SiteSincTests/RepeaterMediaSupportTests.swift
@@ -1,0 +1,200 @@
+import XCTest
+@testable import SiteSinc
+
+final class RepeaterMediaSupportTests: XCTestCase {
+
+    func testDataURLRoundTrip() {
+        let original = Data("jpeg-bytes".utf8)
+        let url = RepeaterMediaSupport.dataURL(fromJPEG: original)
+        XCTAssertTrue(RepeaterMediaSupport.isLocalImagePayload(url))
+        XCTAssertEqual(RepeaterMediaSupport.jpegData(fromStoredImage: url), original)
+    }
+
+    func testParseRowsHandlesNestedCameraObjects() {
+        let json = """
+        [{"name":"Row 1","photo":[{"image":"tenants/1/forms/a.jpg","capturedAt":"2026-01-01T00:00:00Z"}]}]
+        """
+        let rows = RepeaterMediaSupport.parseRows(from: json)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(RepeaterMediaSupport.scalarString(rows[0]["name"]), "Row 1")
+        XCTAssertFalse(RepeaterMediaSupport.isEmptyValue(rows[0]["photo"]))
+        let items = RepeaterMediaSupport.mediaItems(fromStoredValue: rows[0]["photo"]!, isCamera: true)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].remoteRef, "tenants/1/forms/a.jpg")
+    }
+
+    func testStringDictsSurviveNestedObjects() {
+        let json = """
+        [{"note":"ok","image":["data:image/jpeg;base64,QQ=="]}]
+        """
+        let rows = RepeaterMediaSupport.rowsAsStringDicts(from: json)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0]["note"], "ok")
+        let refs = RepeaterMediaSupport.parseImageRefs(rows[0]["image"]!)
+        XCTAssertEqual(refs.count, 1)
+        XCTAssertTrue(RepeaterMediaSupport.isLocalImagePayload(refs[0]))
+    }
+
+    func testEncodeImageItemsSingleAndMultiple() {
+        let one = RepeaterMediaItem(jpegData: Data("a".utf8))
+        XCTAssertTrue(RepeaterMediaSupport.encodeImageItems([one]).hasPrefix("data:image/jpeg;base64,"))
+
+        let two = [
+            RepeaterMediaItem(jpegData: Data("a".utf8)),
+            RepeaterMediaItem(remoteRef: "tenants/1/forms/b.jpg")
+        ]
+        let encoded = RepeaterMediaSupport.encodeImageItems(two)
+        let refs = RepeaterMediaSupport.parseImageRefs(encoded)
+        XCTAssertEqual(refs.count, 2)
+        XCTAssertEqual(refs[1], "tenants/1/forms/b.jpg")
+    }
+
+    func testEncodeCameraItemsIncludesLocation() {
+        let item = RepeaterMediaItem(
+            jpegData: Data("cam".utf8),
+            capturedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            latitude: 51.5,
+            longitude: -0.1,
+            accuracy: 8,
+            locationTimestamp: 1_700_000_000
+        )
+        let encoded = RepeaterMediaSupport.encodeCameraItems([item])
+        let dicts = RepeaterMediaSupport.parseCameraDicts(encoded)
+        XCTAssertEqual(dicts.count, 1)
+        XCTAssertNotNil(dicts[0]["capturedAt"] as? String)
+        let loc = dicts[0]["location"] as? [String: Any]
+        XCTAssertEqual(loc?["latitude"] as? Double, 51.5)
+        XCTAssertEqual(loc?["longitude"] as? Double, -0.1)
+    }
+
+    func testEmptyMediaIsEmptyValue() {
+        XCTAssertTrue(RepeaterMediaSupport.isEmptyValue(""))
+        XCTAssertTrue(RepeaterMediaSupport.isEmptyValue("[]"))
+        XCTAssertTrue(RepeaterMediaSupport.isEmptyValue([Any]()))
+        XCTAssertFalse(RepeaterMediaSupport.isEmptyValue("data:image/jpeg;base64,QQ=="))
+        XCTAssertFalse(RepeaterMediaSupport.isEmptyValue(["tenants/1/forms/a.jpg"]))
+    }
+
+    func testExpandRowsPromotesCameraJSON() throws {
+        let cameraJSON = RepeaterMediaSupport.encodeCameraItems([
+            RepeaterMediaItem(remoteRef: "tenants/1/forms/a.jpg", capturedAt: Date())
+        ])
+        let rows = [["title": "A", "cam": cameraJSON]]
+        let field = makeField(id: "cam", type: "camera")
+        let expanded = RepeaterMediaSupport.expandRowsForStorage(rows, subFields: [field])
+        XCTAssertTrue(expanded[0]["cam"] is [Any])
+        XCTAssertEqual(expanded[0]["title"] as? String, "A")
+    }
+
+    func testRewriteUploadsDataURLsAndKeepsFileKeys() async throws {
+        let jpeg = Data("new-photo".utf8)
+        let dataURL = RepeaterMediaSupport.dataURL(fromJPEG: jpeg)
+        let imageField = makeField(id: "img", type: "image")
+        let cameraField = makeField(id: "cam", type: "camera")
+        let rows: [[String: Any]] = [[
+            "img": dataURL,
+            "cam": [["image": dataURL, "capturedAt": "2026-01-01T00:00:00Z"]],
+            "note": "keep"
+        ]]
+
+        var uploadedNames: [String] = []
+        let rewritten = try await RepeaterMediaSupport.rewriteRowsForSubmission(
+            rows,
+            subFields: [imageField, cameraField],
+            parentFieldId: "repeater1",
+            uploadJPEG: { data, name in
+                uploadedNames.append(name)
+                XCTAssertEqual(data, jpeg)
+                return "tenants/1/forms/\(name)"
+            },
+            fileKeyFromRef: { RepeaterMediaSupport.fileKey(from: $0) }
+        )
+
+        XCTAssertEqual(uploadedNames.count, 2)
+        XCTAssertEqual(rewritten[0]["img"] as? String, "tenants/1/forms/\(uploadedNames[0])")
+        let cam = rewritten[0]["cam"] as? [[String: Any]]
+        XCTAssertEqual(cam?.first?["image"] as? String, "tenants/1/forms/\(uploadedNames[1])")
+        XCTAssertEqual(rewritten[0]["note"] as? String, "keep")
+    }
+
+    func testRewriteLeavesExistingFileKeys() async throws {
+        let imageField = makeField(id: "img", type: "image")
+        let rows: [[String: Any]] = [[
+            "img": "https://cdn.example.com/tenants/9/forms/kept.jpg?X-Amz-Algorithm=AWS4"
+        ]]
+        var uploadCount = 0
+        let rewritten = try await RepeaterMediaSupport.rewriteRowsForSubmission(
+            rows,
+            subFields: [imageField],
+            parentFieldId: "rep",
+            uploadJPEG: { _, _ in
+                uploadCount += 1
+                return "should-not-upload"
+            },
+            fileKeyFromRef: { RepeaterMediaSupport.fileKey(from: $0) }
+        )
+        XCTAssertEqual(uploadCount, 0)
+        XCTAssertEqual(rewritten[0]["img"] as? String, "tenants/9/forms/kept.jpg")
+    }
+
+    func testFileKeyExtractsTenantsPath() {
+        XCTAssertEqual(
+            RepeaterMediaSupport.fileKey(from: "tenants/1/forms/a.jpg"),
+            "tenants/1/forms/a.jpg"
+        )
+        XCTAssertEqual(
+            RepeaterMediaSupport.fileKey(from: "https://cdn.example.com/tenants/1/forms/a.jpg?X-Amz-Algorithm=AWS4"),
+            "tenants/1/forms/a.jpg"
+        )
+    }
+
+    func testValidationFindsMissingRequiredImage() {
+        let imageField = makeField(id: "img", type: "image", required: true)
+        let json = #"[{"img":""}]"#
+        let issue = RepeaterMediaSupport.firstValidationIssue(in: json, subFields: [imageField])
+        guard case .missingRequired(let row, let field)? = issue else {
+            return XCTFail("Expected missing required image")
+        }
+        XCTAssertEqual(row, 0)
+        XCTAssertEqual(field.id, "img")
+    }
+
+    func testValidationPassesFilledImageArray() {
+        let imageField = makeField(id: "img", type: "image", required: true)
+        let json = #"[{"img":["tenants/1/forms/a.jpg"]}]"#
+        XCTAssertNil(RepeaterMediaSupport.firstValidationIssue(in: json, subFields: [imageField]))
+    }
+
+    func testMediaKeyParseAllowsUnderscoresInFieldId() {
+        let key = RepeaterMediaSupport.mediaKey(fieldId: "site_photo", rowIndex: 2)
+        let parsed = RepeaterMediaSupport.parseMediaKey(key)
+        XCTAssertEqual(parsed?.fieldId, "site_photo")
+        XCTAssertEqual(parsed?.rowIndex, 2)
+    }
+
+    private func makeField(id: String, type: String, required: Bool = false) -> FormField {
+        FormField(
+            id: id,
+            label: id,
+            type: type,
+            required: required,
+            options: nil,
+            subFields: nil,
+            minItems: nil,
+            maxItems: nil,
+            addButtonText: nil,
+            removeButtonText: nil,
+            description: nil,
+            placeholder: nil,
+            submissionRequirement: nil,
+            closeoutSettings: nil,
+            tableColumns: nil,
+            minRows: nil,
+            maxRows: nil,
+            enableRowNames: nil,
+            rowNameLabel: nil,
+            tableMode: nil,
+            staticRows: nil
+        )
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Camera and image subfields inside form repeaters were stubbed out with a disabled “coming soon” control, so photos could not be captured, selected, or submitted.

This wires repeater `image` / `camera` (and `photo`) fields to the same capture flow used by top-level form photos:

- Image subfields: photo library picker, previews, remove
- Camera subfields: take photo (multi-shot camera) or library, optional markup, remove
- Existing saved photos load for edit
- On submit, local JPEGs are uploaded and replaced with file keys; camera rows keep `capturedAt` / location metadata
- Submission detail can display nested photos, including camera objects and data-URL images

## Test plan
- [ ] Create a form with a repeater that has an **image** subfield: add a row, pick photos, remove one, submit, confirm they appear on the submission detail
- [ ] Same form with a **camera** subfield: take photos and pick from library, mark one up, submit, confirm they appear
- [ ] Required image/camera subfields block submit until a photo is added
- [ ] Edit an existing submission that already has repeater photos and add/remove photos without losing the originals
- [ ] Unit tests in `RepeaterMediaSupportTests` cover encode/decode, upload rewrite, file-key extraction, and required-field validation

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc797a6e-9c30-4c96-b4fa-a55124d8283a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc797a6e-9c30-4c96-b4fa-a55124d8283a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

